### PR TITLE
Easier report of failed extraction

### DIFF
--- a/assets/js/templates/main.js
+++ b/assets/js/templates/main.js
@@ -38,7 +38,7 @@ const dplNotice = (state) => {
   const title = encodeURIComponent('Extraction failed');
   return state.parserMessage === '' ? '' : html`
     <span class="error">${state.parserMessage}</span>
-    <a href="https://github.com/ndaidong/article-parser/issues/new?title=${title}" target="_blank">Report</a>
+    <a href="https://github.com/ndaidong/article-parser/issues/new?title=${title}&body=${encodeURIComponent(state.parserMessage)}" target="_blank">Report</a>
   `;
 };
 


### PR DESCRIPTION
When clicking "Report" after a failed extraction the new issue form will be prefilled with the parser error message.